### PR TITLE
NSTextView with Smart Quotes disabled, still replaces quotes automatically

### DIFF
--- a/Quill/Classes/MainViewController.m
+++ b/Quill/Classes/MainViewController.m
@@ -30,6 +30,11 @@
     return self;
 }
 
+- (void)loadView {
+    [super loadView];
+    [textView_ setAutomaticQuoteSubstitutionEnabled:NO];
+}
+
 #pragma mark - IBActions
 
 - (IBAction)pressAdd:(id)sender {


### PR DESCRIPTION
straight quotes: `""`
-> smart quotes:  `“”`
